### PR TITLE
Small fixes for OneShotEnv registration and warnings raised by UnconstrainedActionManager

### DIFF
--- a/src/scml/oneshot/rl/action.py
+++ b/src/scml/oneshot/rl/action.py
@@ -187,10 +187,10 @@ class UnconstrainedActionManager(ActionManager):
         for partner, (q, p) in zip(partners, action, strict=True):
             nmi = nmis.get(partner, None)
             if not nmi:
-                warnings.warn(
-                    f"Did not find {partner} in the list of partners"
-                    f"\n{partners=}\n{awi.my_partners=}\n{action=}"
-                )
+                # warnings.warn(
+                #     f"Did not find {partner} in the list of partners"
+                #     f"\n{partners=}\n{awi.my_partners=}\n{action=}"
+                # )
                 scaled.append((0, 0))
                 continue
             qscale = nmi.issues[QUANTITY].max_value / (self.max_quantity - 1)

--- a/src/scml/oneshot/rl/env.py
+++ b/src/scml/oneshot/rl/env.py
@@ -133,6 +133,6 @@ class OneShotEnv(gym.Env):
 
 register(
     id="scml/OneShot-v0",
-    entry_point="scml.oneshot.rl.env:GridWorldEnv",
+    entry_point="scml.oneshot.rl.env:OneShotEnv",
     max_episode_steps=None,
 )


### PR DESCRIPTION
Two small issues have been fixed:

1. The Gymnasium registration for OneShotEnv was incorrect - the updated registration now allows OneShotEnvs to be created using gym.make() (this was normally not used anyways).
2. The UnconstrainedActionManager would raise a warning every time it did not find a partner NMI. However, the default behavior of awi.my_partners would only return NMIs for currently active negotiations, so the warning would be raised very frequently and unnecessarily. 